### PR TITLE
[waiting if we need it] patch activefedora to support timeout config

### DIFF
--- a/app/overrides/active_fedora/fedora_override.rb
+++ b/app/overrides/active_fedora/fedora_override.rb
@@ -1,0 +1,27 @@
+# Override to add a timeout option to fedora.yml config, so we can increase it.
+# Should be in some future ActiveFedora after 11.4.0.
+# https://github.com/samvera/active_fedora/issues/1105
+
+# timeout value in fedora.yml is in SECONDS
+
+if Gem.loaded_specs["active-fedora"].version >= Gem::Version.new('11.4.0')
+   msg = "
+   Please check and make sure this patch is still needed\
+  at #{__FILE__}:#{__LINE__}\n\n"
+   $stderr.puts msg
+   Rails.logger.warn msg
+end
+
+module ActiveFedoraOverride
+  def authorized_connection
+    super.tap do |conn|
+      if @config[:timeout] && @config[:timeout].to_i > 0
+        conn.options[:timeout] = @config[:timeout].to_i
+      end
+    end
+  end
+end
+
+ActiveFedora::Fedora.class_eval do
+  prepend ActiveFedoraOverride unless self.class.include?(ActiveFedoraOverride)
+end

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -3,6 +3,7 @@ development:
   password: <%= ENV['HYDRA_FEDORA_PASSWORD_DEVELOPMENT'] || 'fedoraAdmin' %>
   url: <%= ENV['HYDRA_FEDORA_URL_DEVELOPMENT'] || 'http://127.0.0.1:8080/rest' %>
   base_path: <%= ENV['HYDRA_FEDORA_BASE_PATH_DEVELOPMENT'] || '/dev' %>
+  timeout: 10 # seconds!!! supported only by patch we added if we're using an activefedora <= 11.4
 profile:
   user: <%= ENV['HYDRA_FEDORA_USER_DEVELOPMENT'] || 'fedoraAdmin' %>
   password: <%= ENV['HYDRA_FEDORA_PASSWORD_DEVELOPMENT'] || 'fedoraAdmin' %>


### PR DESCRIPTION
Would need edit to fedora.yml to add a timeout value, which I think is ansible-controlled