### PR TITLE
Feature to log out admin logins while leaving public app up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,23 @@ class User < ApplicationRecord
     groups.include? 'registered'
   end
 
+  # A devise method, we're taking advantage of it for a cheesy way to lock out
+  # admin users based on CHF::Env variable.
+  def active_for_authentication?
+    if CHF::Env.lookup(:logins_disabled)
+      false
+    else
+      super
+    end
+  end
+  def inactive_message
+    if CHF::Env.lookup(:logins_disabled)
+      "Sorry, logins are temporarily disabled for some software maintenance."
+    else
+      super
+    end
+  end
+
   # Use on a current_user to ensure it's not a guest / nil object user
   alias_method :logged_in?, :persisted?
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,22 @@
+
+# Cheesy hacky way to disable login form, replacing with message, when we have logins disabled
+
+original_responder = Devise::SessionsController.responder
+Rails.application.config.to_prepare do
+  Devise::SessionsController.responder = proc do |controller, resources, options|
+    if CHF::Env.lookup(:logins_disabled)
+      controller.render layout: true, status: 403, html: <<-EOF.html_safe
+        <h1>Sorry, staff logins are temporarily disabled.</h1>
+        <p>Some software maintenance is going on.</p>
+        <p><A href='#{ controller.root_path }'>Return to app</a></p>
+      EOF
+    else
+      original_responder.call(controller, resources, options)
+    end
+  end
+end
+
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|

--- a/lib/chf/env.rb
+++ b/lib/chf/env.rb
@@ -239,5 +239,9 @@ module CHF
 
     define_key :honeybadger_api_key
 
+    # We may temporarily change this default value below and redeploy, instead of actually
+    # changing in ENV/local_env.yml for now, cause we don't have a great way to do that
+    # temporarily.
+    define_key :logins_disabled, default: false, system_env_transform: BOOLEAN_TRANSFORM
   end
 end


### PR DESCRIPTION
Implemented super cheesy hacky. 

1. Hook into a devise feature meant for user 'activation' to let all users not login
2. be even meaner to devise by using some hacky ruby/rails craziness to tell it not to present
   the usual login screen if we have logins disabled. 

If we set logins to be disabled, and a logged in user accesses the app, they will be immediately logged out. 
If they were trying to do something that required a login, they'll be redirected to the 'login' screen, which
has been replaced with a message actually saying "Sorry, logins disabled."

They'll have to login again when logins are no longer disabled. 

If they never accessed the app when logins were disabled, they'll find themselves still logged in after the window though. But if they acccess during window, they'll get logged out and have to log in again.

Closes #1014 