### PR TITLE
index MIME/IANA content-types for works

### DIFF
--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -77,6 +77,13 @@ module CHF
 
         # index structured date of works, so we can get them at index time
         doc['date_of_work_json_ssm'] = object.date_of_work.collect { |d| d.to_json(except: "id") }
+
+        # Need all content-types for oai_dc serialization. This does force loading all members, was
+        # that happening already, will it be a performance problem?
+        doc['content_types_ssim'] = object.members.collect do |member|
+          # We're NOT descending into child generic works, too crazy performance-wise.
+          member.mime_type if member.respond_to?(:mime_type)
+        end.uniq
       end
     end
 

--- a/spec/indexers/chf/generic_work_indexer_spec.rb
+++ b/spec/indexers/chf/generic_work_indexer_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe CHF::GenericWorkIndexer do
     expect(solr_document[mapper.solr_name('maker_facet', :facetable)].size).to eq 3
   end
 
+  describe "with a real file child" do
+    let (:work) do
+      FactoryGirl.create(:generic_work, :real_public_image, dates_of_work: [])
+    end
+    it "indexes content-type" do
+      expect(solr_document['content_types_ssim']).to eq ["image/jpeg"]
+    end
+  end
+
   # These are slow, was hard to get them to work reliably and be reliably testing at all
   describe "representative fields" do
     let(:width) { 100 }


### PR DESCRIPTION
* Needed for DPLA oai-dc metadata, dc:format, PA Digital recommends. ref #965
* Am a bit worried about it slowing down indexing, if indexing wasn't already fetching all members. But it appears to be okay for our standard use cases, in limited tests. Not sure if indexing was already pulling in members.
* For reasons of above, this does NOT try to descend into work-member children, just top level fileset children.