### PR TITLE
WIP Batch edit changes

### DIFF
--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -95,6 +95,13 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
     end
 
     def initialize_combined_fields
+      # This overrides the superclass,
+      # https://github.com/samvera/sufia/blob/v7.4.0/app/forms/sufia/forms/batch_edit_form.rb
+      # The goal here is to allow single-value fields to be edited via the form.
+      # To determine whether a field expects a single value or an array, we check the model's properties.
+      # If the field accepts an array, we process it as in the superclass. If it accepts a single value,
+      # then we process it slightly differently, storing the values in plain_attributes
+      # instead of combined_attributes.
 
       plain_attributes = {}
       combined_attributes = {}

--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -90,19 +90,22 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
       clean_params
     end
 
-    def accepts_multiple_values(prop)
+    # If this property of the model is an array (which is the default) then return true.
+    # If it accepts only one value, return false.
+    # Note that this value is stored as a boolean in the properties of the model class.
+    def accepts_multiple_values?(prop)
       model_class.properties[prop.to_s].instance_values['opts'][:multiple]
     end
 
-    def initialize_combined_fields
-      # This overrides the superclass,
-      # https://github.com/samvera/sufia/blob/v7.4.0/app/forms/sufia/forms/batch_edit_form.rb
-      # The goal here is to allow single-value fields to be edited via the form.
-      # To determine whether a field expects a single value or an array, we check the model's properties.
-      # If the field accepts an array, we process it as in the superclass. If it accepts a single value,
-      # then we process it slightly differently, storing the values in plain_attributes
-      # instead of combined_attributes.
 
+    # This overrides the superclass,
+    # https://github.com/samvera/sufia/blob/v7.4.0/app/forms/sufia/forms/batch_edit_form.rb
+    # The goal here is to allow single-value fields to be edited via the form.
+    # To determine whether a field expects a single value or an array, we check the model's properties.
+    # If the field accepts an array, we process it as in the superclass. If it accepts a single value,
+    # then we process it slightly differently, storing the values in plain_attributes
+    # instead of combined_attributes.
+    def initialize_combined_fields
       plain_attributes = {}
       combined_attributes = {}
       permissions = []
@@ -110,7 +113,7 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
       batch_document_ids.each do |doc_id|
         work = model_class.find(doc_id)
         terms.each do |key|
-          if accepts_multiple_values(key)
+          if accepts_multiple_values?(key)
             combined_attributes[key] ||= []
             combined_attributes[key] = (combined_attributes[key] +  work[key].to_a).uniq
           else
@@ -122,7 +125,7 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
       end
 
       terms.each do |key|
-        if accepts_multiple_values(key)
+        if accepts_multiple_values?(key)
           # if value is empty, we create an one element array to loop over for output
           model[key] = combined_attributes[key].empty? ? [''] : combined_attributes[key]
         else

--- a/spec/features/batch_edit_bug_spec.rb
+++ b/spec/features/batch_edit_bug_spec.rb
@@ -12,9 +12,9 @@ you_want_this_test_to_fail = false
 
 # Change the above to true and this test will fail.
 
-RSpec.feature "Batch Edit form", js: true do
+RSpec.feature "BatchEditForm", js: true do
   let(:user) { FactoryGirl.create(:depositor) }
-  scenario "Demonstrate bug with batch editing empty property array" do
+  scenario "demonstrate bug with batch editing empty property array" do
     login_as(user, :scope => :user)
     Capybara.default_max_wait_time=60
     visit new_curation_concerns_generic_work_path

--- a/spec/features/batch_edit_bug_spec.rb
+++ b/spec/features/batch_edit_bug_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+# BUG REPORT:
+# *If* you start with an item with the "rights" property set to an empty array,
+# *and* you attempt to set its "rights" to "In Copyright"
+# via the batch edit screen,
+# its "rights" property is unaffected. Instead, it shold be set to
+# [ "http://rightsstatements.org/vocab/InC/1.0/" ].
+# This appears to be pre-existing bug in Sufia.
+
+you_want_this_test_to_fail = false
+
+# Change the above to true and this test will fail.
+
+RSpec.feature "Batch Edit form", js: true do
+  let(:user) { FactoryGirl.create(:depositor) }
+  scenario "Demonstrate bug with batch editing empty property array" do
+    login_as(user, :scope => :user)
+    Capybara.default_max_wait_time=60
+    visit new_curation_concerns_generic_work_path
+    fill_in("generic_work[title]", with: 'Title of work to edit')
+    within(".form-group.generic_work_identifier") do
+      within first(".field-wrapper") do
+        select "Sierra Bib. No."
+        fill_in "generic_work[bib_external_id][]", with: 'abcde'
+      end
+    end
+    select "Image", from: "generic_work[resource_type][]"
+    choose "Your Institution"
+    click_button "Save"
+    work = GenericWork.first
+    work_id = work.id
+    visit '/dashboard/works'
+    expect(work.rights).to eq([])
+    find_by_id("batch_document_#{work_id}").click
+    click_button "Edit Selected"
+    expect(page).to have_content 'Batch Edit Descriptions'
+    click_link 'Rights'
+    select 'In Copyright', :from => 'Rights'
+    click_button "Save changes"
+    expect(page).to have_content 'Changes Saved'
+    new_value = GenericWork.find(work_id).rights
+    if you_want_this_test_to_fail
+      expect(new_value).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+    end
+  end
+end

--- a/spec/features/batch_edit_bug_spec.rb
+++ b/spec/features/batch_edit_bug_spec.rb
@@ -8,13 +8,12 @@ require 'rails_helper'
 # [ "http://rightsstatements.org/vocab/InC/1.0/" ].
 # This appears to be pre-existing bug in Sufia.
 
-you_want_this_test_to_fail = false
-
-# Change the above to true and this test will fail.
 
 RSpec.feature "BatchEditForm", js: true do
   let(:user) { FactoryGirl.create(:depositor) }
-  scenario "demonstrate bug with batch editing empty property array" do
+
+  scenario "bug with batch editing empty property array",
+    :skip => "someday we may want to fix this bug"  do
     login_as(user, :scope => :user)
     Capybara.default_max_wait_time=60
     visit new_curation_concerns_generic_work_path
@@ -40,8 +39,6 @@ RSpec.feature "BatchEditForm", js: true do
     click_button "Save changes"
     expect(page).to have_content 'Changes Saved'
     new_value = GenericWork.find(work_id).rights
-    if you_want_this_test_to_fail
-      expect(new_value).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
-    end
+    expect(new_value).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
   end
 end

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature "BatchEditForm", js: true do
 
   scenario "batch edit division, file creator, rights holder and genre" do
     login_as(user, :scope => :user)
-    Capybara.default_max_wait_time=60
     w1, w2, w3, w4, w5 = GenericWork.all
     new_test_work('abc', 'xyz')
     my_work = GenericWork.where(title: ["abc"]).first
@@ -64,7 +63,9 @@ RSpec.feature "BatchEditForm", js: true do
       fill_in "generic_work[#{field}]", with: value
     end
     click_button "Save changes"
-    expect(page).to have_content 'Changes Saved'
+    using_wait_time 30 do
+      expect(page).to have_content 'Changes Saved'
+    end
     # check that values were changed as expected
     get_properties(field).each do | id, new_value |
       if ids_to_change.include? id
@@ -77,7 +78,6 @@ RSpec.feature "BatchEditForm", js: true do
 
   def edit_batch_multi_valued(ids, which_items, field, field_label, value, value_label)
     visit '/dashboard/works'
-    Capybara.page.current_window.resize_to(1600, 3000)
     values_beforehand = get_properties(field)
     ids_to_change=ids.values_at(*which_items)
     ids_to_change.each { |id| find_by_id("batch_document_#{id}").click }

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "BatchEditForm", js: true do
 
   scenario "batch edit division, file creator, rights holder and genre" do
     login_as(user, :scope => :user)
-    Capybara.default_max_wait_time=600
+    Capybara.default_max_wait_time=60
     w1, w2, w3, w4, w5 = GenericWork.all
     new_test_work('abc', 'xyz')
     my_work = GenericWork.where(title: ["abc"]).first

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Batch Edit form", js: true do
   let(:user) { FactoryGirl.create(:depositor) }
+
   let!(:w1) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
   let!(:w2) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
   let!(:w3) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
@@ -15,36 +16,24 @@ RSpec.feature "Batch Edit form", js: true do
 
   scenario "Create six new works, then batch edit three of them." do
     w1, w2, w3, w4, w5 = GenericWork.all
-    new_test_work('Title 1', 'xyz')
-    my_work = GenericWork.where(title: ["Title 1"]).first
+    new_test_work('abc', 'xyz')
+    my_work = GenericWork.where(title: ["abc"]).first
     aci = my_work.access_control_id
 
-    # Just a quick hack so these works actually
-    # show up on the "My Works" page. Otherwise we
-    # can't batch-edit them.
+    # This is a hack to avoid having to create
+    # Fedora access control objects asssociated with the works.
+    # The goal here is to get these works to show up on the
+    # My Works page, so they can be batch-edited.
     [w1, w2, w3, w4, w5].each do |w|
       w.access_control_id=aci
       w.depositor='depositor@example.com'
       w.save
     end
+    ids = GenericWork.all.map { |gw|  gw.id }
+    edit_batch(ids, [1,2,3], 'division', 'Department', 'Center for Oral History')
+    edit_batch(ids, [0,3,5], 'file_creator', 'File creator', 'Tobias, Gregory')
+    edit_batch(ids, [3, 4], 'rights_holder', 'Rights holder', 'Ludwig van Beethoven', false)
 
-
-    visit '/dashboard/works'
-    find_by_id("batch_document_#{w2.id}").click
-    find_by_id("batch_document_#{w3.id}").click
-    find_by_id("batch_document_#{w4.id}").click
-    click_button "Edit Selected"
-    click_link "Department"
-    select "Center for Oral History", from: "generic_work[division]"
-    click_button "Save changes"
-    expect(page).to have_content 'Changes Saved'
-    w1, w2, w3, w4, w5, w6 = GenericWork.all
-    expect( w1.division).to eq('Library')
-    expect( w2.division).to eq('Center for Oral History')
-    expect( w3.division).to eq('Center for Oral History')
-    expect( w4.division).to eq('Center for Oral History')
-    expect( w5.division).to eq('Library')
-    expect( w6.division).to eq('')
   end
 
   def new_test_work(title, bib_num)
@@ -61,4 +50,41 @@ RSpec.feature "Batch Edit form", js: true do
       click_button "Save"
       puts "Saved a work."
   end
+
+  # Batch edits a number of Generic Works, whose indices are specified in which_items,
+  # so that their "field" value is set to "value". Checks that the modification
+  # did take place, and that the same field on other GenericWorks were not affected.
+  def edit_batch(ids, which_items, field, field_label, value, dropdown=true)
+    visit '/dashboard/works'
+    #check values beforehand
+    values_beforehand = get_properties(field)
+    #make the change
+    ids_to_change=ids.values_at(*which_items)
+    ids_to_change.each { |id| find_by_id("batch_document_#{id}").click }
+    click_button "Edit Selected"
+    click_link field_label
+
+    if dropdown
+      select value, from: "generic_work[#{field}]"
+    else
+      fill_in "generic_work[#{field}]", with: value
+    end
+
+    click_button "Save changes"
+
+    expect(page).to have_content 'Changes Saved'
+    # check that values were changed as expected
+    get_properties(field).each do | id, new_value |
+      if ids_to_change.include? id
+        expect( new_value).to eq(value)
+      else
+        expect( new_value).to eq(values_beforehand[id])
+      end
+    end
+  end
+
+  def get_properties(field)
+    GenericWork.all.map { |gw| [gw.id, gw[field]] }.to_h
+  end
+
 end

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -8,11 +8,9 @@ RSpec.feature "Batch Edit form", js: true do
   let!(:w4) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
   let!(:w5) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
 
-  scenario "Batch edit division, file creator and rights holder" do
-    ids = nil
+  scenario "Batch edit division, file creator, rights holder and genre" do
     login_as(user, :scope => :user)
-    Capybara.page.current_window.resize_to(1600, 3000)
-    Capybara.default_max_wait_time=10
+    Capybara.default_max_wait_time=60
     w1, w2, w3, w4, w5 = GenericWork.all
     new_test_work('abc', 'xyz')
     my_work = GenericWork.where(title: ["abc"]).first
@@ -28,14 +26,10 @@ RSpec.feature "Batch Edit form", js: true do
       w.depositor='depositor@example.com'
       w.save
     end
-    edit_batch_single_valued(ids, [1,2,3], 'division',      'Department',    'Center for Oral History')
-    edit_batch_single_valued(ids, [0,3,5], 'file_creator',  'File creator',  'Tobias, Gregory')
-    edit_batch_single_valued(ids, [3, 4],  'rights_holder', 'Rights holder', 'Ludwig van Beethoven', false)
-    edit_batch_multi_valued(ids, [3,4,5], 'genre_string',  'Genre',  'Pesticides', 'Pesticides')
-    # Why does this break???
-    #edit_batch_multi_valued(ids, [1,3,5],     'rights',  'Rights', 'http://rightsstatements.org/vocab/InC/1.0/', 'In Copyright')
-
-
+    edit_batch_single_valued(ids, [1,2,3], 'division',      'Department',     'Center for Oral History')
+    edit_batch_single_valued(ids, [0,3,5], 'file_creator',  'File creator',   'Tobias, Gregory')
+    edit_batch_single_valued(ids, [3,4],   'rights_holder', 'Rights holder',  'Ludwig van Beethoven', false)
+    edit_batch_multi_valued(ids,  [3,4,5], 'genre_string',  'Genre',          'Pesticides',    'Pesticides')
   end
 
   def new_test_work(title, bib_num)

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.feature "Batch Edit form", js: true do
+  let(:user) { FactoryGirl.create(:depositor) }
+  let!(:w1) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
+  let!(:w2) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
+  let!(:w3) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
+  let!(:w4) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
+  let!(:w5) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
+
+  before do
+    login_as(user, :scope => :user)
+    Capybara.page.current_window.resize_to(1600, 1200)
+  end
+
+  scenario "Create six new works, then batch edit three of them." do
+    w1, w2, w3, w4, w5 = GenericWork.all
+    new_test_work('Title 1', 'xyz')
+    my_work = GenericWork.where(title: ["Title 1"]).first
+    aci = my_work.access_control_id
+
+    # Just a quick hack so these works actually
+    # show up on the "My Works" page. Otherwise we
+    # can't batch-edit them.
+    [w1, w2, w3, w4, w5].each do |w|
+      w.access_control_id=aci
+      w.depositor='depositor@example.com'
+      w.save
+    end
+
+
+    visit '/dashboard/works'
+    find_by_id("batch_document_#{w2.id}").click
+    find_by_id("batch_document_#{w3.id}").click
+    find_by_id("batch_document_#{w4.id}").click
+    click_button "Edit Selected"
+    click_link "Department"
+    select "Center for Oral History", from: "generic_work[division]"
+    click_button "Save changes"
+    expect(page).to have_content 'Changes Saved'
+    w1, w2, w3, w4, w5, w6 = GenericWork.all
+    expect( w1.division).to eq('Library')
+    expect( w2.division).to eq('Center for Oral History')
+    expect( w3.division).to eq('Center for Oral History')
+    expect( w4.division).to eq('Center for Oral History')
+    expect( w5.division).to eq('Library')
+    expect( w6.division).to eq('')
+  end
+
+  def new_test_work(title, bib_num)
+      visit new_curation_concerns_generic_work_path
+      fill_in("generic_work[title]", with: title)
+      within(".form-group.generic_work_identifier") do
+        within first(".field-wrapper") do
+          select "Sierra Bib. No."
+          fill_in "generic_work[bib_external_id][]", with: bib_num
+        end
+      end
+      select "Image", from: "generic_work[resource_type][]"
+      choose "Your Institution"
+      click_button "Save"
+      puts "Saved a work."
+  end
+end

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "BatchEditForm", js: true do
 
   scenario "batch edit division, file creator, rights holder and genre" do
     login_as(user, :scope => :user)
-    Capybara.default_max_wait_time=60
+    Capybara.default_max_wait_time=600
     w1, w2, w3, w4, w5 = GenericWork.all
     new_test_work('abc', 'xyz')
     my_work = GenericWork.where(title: ["abc"]).first

--- a/spec/features/batch_edit_feature_spec.rb
+++ b/spec/features/batch_edit_feature_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Batch Edit form", js: true do
+RSpec.feature "BatchEditForm", js: true do
   let(:user) { FactoryGirl.create(:depositor) }
   let!(:w1) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
   let!(:w2) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
@@ -8,7 +8,7 @@ RSpec.feature "Batch Edit form", js: true do
   let!(:w4) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
   let!(:w5) { FactoryGirl.create(:generic_work, :with_complete_metadata) }
 
-  scenario "Batch edit division, file creator, rights holder and genre" do
+  scenario "batch edit division, file creator, rights holder and genre" do
     login_as(user, :scope => :user)
     Capybara.default_max_wait_time=60
     w1, w2, w3, w4, w5 = GenericWork.all

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe BatchEditForm do
     subject { form.terms }
     it do
       is_expected.to eq [
+        :division,
+        :rights_holder,
+        :file_creator,
         :additional_title,
         :identifier,
         :admin_note,


### PR DESCRIPTION
Fixes #925 
This is only a first try, and probably contains bugs. Obviously a screwed-up batch edit attempt could ruin a lot of metadata, so it's worth testing this really carefully.
* I pulled method initialize_combined_fields from the superclass and modified it so it works with single-value fields.
* I'm also adding rights_holder and file_creator to this, as they seem to work largely the same way. Obviously we may not want them in the form, but I figured why not.
