### PR TITLE
get fileset to index visibility

### DIFF
--- a/app/indexers/chf/file_set_indexer.rb
+++ b/app/indexers/chf/file_set_indexer.rb
@@ -27,6 +27,9 @@ module CHF
         if candidate_file_size && candidate_file_size =~ /(\d+)/
           doc[file_size_key] = $1
         end
+
+        # So we can filter on visibility from solr docs
+        doc['visibility_ssi'] = object.visibility
       end
     end
   end


### PR DESCRIPTION
so we can filter to just public, in memory.

Needed for PDF creation, make a PDF of just public members

This stack is so ridiculous.