### PR TITLE
Duplicate date bugfix

### DIFF
--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -76,6 +76,9 @@ module CHF
         doc['visibility_ssi'] = object.visibility
 
         # index structured date of works, so we can get them at index time
+        # Not totally sure why we're getting duplicates here, the duplicates don't seem to make it to fedora,
+        # but we have dups as input here when indexing after an edit. We just de-dup here for now to avoid
+        # dups in index.
         doc['date_of_work_json_ssm'] = remove_duplicates('date_of_work').collect { |d| d.to_json(except: "id") }
 
         # Need all content-types for oai_dc serialization. This does force loading all members, was

--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -76,7 +76,7 @@ module CHF
         doc['visibility_ssi'] = object.visibility
 
         # index structured date of works, so we can get them at index time
-        doc['date_of_work_json_ssm'] = object.date_of_work.collect { |d| d.to_json(except: "id") }
+        doc['date_of_work_json_ssm'] = remove_duplicates('date_of_work').collect { |d| d.to_json(except: "id") }
 
         # Need all content-types for oai_dc serialization. This does force loading all members, was
         # that happening already, will it be a performance problem?

--- a/spec/features/new_work_feature_spec.rb
+++ b/spec/features/new_work_feature_spec.rb
@@ -91,6 +91,11 @@ RSpec.feature "Work form", js: true do
     expect(page).to have_text(artist_name)
     expect(page).to have_text(publisher_name)
     expect(page).to have_text("circa #{date}")
+
+    # Regression test for bug
+    # https://github.com/sciencehistory/chf-sufia/issues/1049
+    expect(page.all(:xpath, '//span[@itemprop="date_created"]').count).to eq 1
+
     expect(page).to have_css(".show-permission-badge", text: I18n.t("sufia.institution_name").upcase)
     inscription_fields.each {|item| expect(page).to have_text(item)}
 


### PR DESCRIPTION
This is a potential fix for #1049 .

Here's what I think is going on:

1) The generic work indexer is not deduplicating date objects before indexing them, as it does for some of the other fields it handles. This leads to duplicates in the SOLR field date_of_work_json_ssm .

2) The way the front-end display handled dates until a couple weeks ago masked this problem by deduplicating the date_of_work_json_ssm items at display time. ( I haven't investigated quite how yet.)

3) When [I changed the way front-end dates were displayed a couple weeks ago](https://github.com/sciencehistory/chf-sufia/commit/2556ae9cc3154025772a76c8d94ed4d4037c9d12), I used the data in date_of_work_json_ssm directly, thus exposing the problem described in 1).

I feel the best way to fix this problem is to modify the generic work indexer, which this PR does. My sense is that fixing this problem lower in the stack makes more sense, as duplicate dates in the date_of_work_json_ssm index could lead to more trouble down the line.

The data in Fedora doesn't appear to contain these duplicates, so, assuming we go this route, a reindex of the items edited since March 20th ( [when field date_of_work_json_ssm was introduced](https://github.com/sciencehistory/chf-sufia/commit/5db10bb75030c9c3ab0a419bfd01b5586375d4b5) ) should fix the problem. We could also run a full reindex, of course.

Quick note: I haven't yet made any further changes to date display in this PR, just to reduce confusion. (I did see your note about it in  issue 1049, @jrochkind , and of course I can easily make that change -- it's just I'd rather deal with this one first).

Also -- I added a regression test for this to the new work feature test.

To run *just* the feature test and then examine the solr field in dev, you might want to try a variation on the following:

```
./bin/rspec spec/features/new_work_feature_spec.rb
curl -vs http://localhost:8985/solr/hydra-test/select?indent=on  2>&1 | grep -5 2010
```

Hope all this makes sense -- let me know how yous feel.