### PR TITLE
Get OAI-PMH feed to include thumbs that don't content-disposition force download

### DIFF
--- a/app/controllers/downloads_controller_override.rb
+++ b/app/controllers/downloads_controller_override.rb
@@ -4,6 +4,11 @@ DownloadsController.class_eval do
   # Since creating these URLs is expensive, we generate links to here, then
   # redirect to S3. Also means we can have bookmarkable non-signed non-expiring
   # links on the actual page.
+  #
+  # Even though this is in downloads controller and has downloads in name,
+  # you can add `&no_content_disposition=true` to header to get a redirect
+  # to S3 response that will NOT have content-disposition header forcing download,
+  # for using "download" images in a web page. Used for OAI-PMH feed for DPLA.
   def s3_download_redirect
     unless CHF::Env.lookup("image_server_downloads").to_s == "dzi_s3"
       raise ActionController::RoutingError.new('Not Found')
@@ -27,7 +32,8 @@ DownloadsController.class_eval do
       file_set_id: file_set_id,
       file_checksum: file_checksum,
       type_key: params[:filename_key],
-      filename_base: filename_base
+      filename_base: filename_base,
+      include_content_disposition: !(params["no_content_disposition"] == "true")
     )
 
     redirect_to s3_url, status: 302

--- a/app/models/chf/oai_dc_serialization.rb
+++ b/app/models/chf/oai_dc_serialization.rb
@@ -201,7 +201,7 @@ module CHF
           file_id: work_presenter.representative_file_id,
           checksum: work_presenter.representative_checksum
         )
-        download_options = service.download_options
+        download_options = service.download_options(no_content_disposition: true)
         url = (download_options.find { |h| h[:option_key] == "medium "} || download_options.first).try { |h| h[:url] }
         # make it an absolute url
         if url

--- a/app/services/chf/create_derivatives_on_s3_service.rb
+++ b/app/services/chf/create_derivatives_on_s3_service.rb
@@ -99,7 +99,10 @@ module CHF
     # 'save as' download file names, and triggers content-disposition: attachment.
     #
     # These can be slow-ish to create due to creating a signed url.
-    def self.s3_url(file_set_id:, file_checksum:, type_key:, filename_base: nil)
+    #
+    # By default redirects to an S3 URL that will have content-disposition headers forcing
+    # download with a good filename. `include_content_disposition: false` will omit content-disposition headers.
+    def self.s3_url(file_set_id:, file_checksum:, type_key:, filename_base: nil, include_content_disposition: true)
       obj = s3_bucket!.object(s3_path(file_set_id: file_set_id, file_checksum: file_checksum, type_key: type_key))
 
       if filename_base
@@ -112,7 +115,7 @@ module CHF
 
         obj.presigned_url(:get,
                           expires_in: 3.days.to_i, # no hurry
-                          response_content_disposition: ApplicationHelper.encoding_safe_content_disposition(file_name))
+                          response_content_disposition: include_content_disposition ? ApplicationHelper.encoding_safe_content_disposition(file_name) : "")
       else
         obj.public_url
       end

--- a/app/services/chf/dzi_s3_url_service.rb
+++ b/app/services/chf/dzi_s3_url_service.rb
@@ -26,25 +26,25 @@ module CHF
 
     # filename_base, if provided, is used to make more human-readable
     # 'save as' download file names.
-    def download_options(filename_base: nil)
+    def download_options(filename_base: nil, no_content_disposition: false)
       return [] unless file_set_id
 
       [
         {
           option_key: "small",
-          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_small", filename_base: filename_base)
+          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_small", filename_base: filename_base, no_content_disposition: no_content_disposition)
         },
         {
           option_key: "medium",
-          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_medium", filename_base: filename_base)
+          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_medium", filename_base: filename_base, no_content_disposition: no_content_disposition)
         },
         {
           option_key: "large",
-          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_large", filename_base: filename_base)
+          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_large", filename_base: filename_base, no_content_disposition: no_content_disposition)
         },
         {
           option_key: "full",
-          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_full_size", filename_base: filename_base)
+          url: Rails.application.routes.url_helpers.s3_download_redirect_path(file_set_id, "dl_full_size", filename_base: filename_base, no_content_disposition: no_content_disposition)
         }
       ]
     end

--- a/app/services/chf/legacy_asset_url_service.rb
+++ b/app/services/chf/legacy_asset_url_service.rb
@@ -29,7 +29,8 @@ module CHF
       "#{thumb_url(size: size)} 1x, #{thumb_url(size: size, density_descriptor: '2X')} 2x"
     end
 
-    def download_options(filename_base: nil)
+    # no_content_disposition there for compat with dzi_s3 service, ignored.
+    def download_options(filename_base: nil, no_content_disposition: false)
       []
     end
   end


### PR DESCRIPTION
Per PA Digital request. We still want to send the "download-medium" size one, which is a nice size, same one we use for fb share.

Had to muck about with our homegrown API for images which has grown confusing and ill-suited for our actual needs, it turns out. Sufia lacked suitable APIs so we had to do something, sorry about the spaghetti. 

Failing on travis because of downloading-solr problem. Confirmed test suite passes locally.