### PR TITLE
WIP have solr_wrapper use mirror_url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,10 @@ group :test do
 end
 
 group :development, :test do
-  gem 'solr_wrapper', '>= 0.3'
+  # Need to get unreleased mirror_url feature so it can download despite being blocked by apache.org on travis,
+  # and our tests can pass again. a release of solr_wrapper 1.3.0 should let us go back to a released gem.
+  gem 'solr_wrapper', git: 'https://github.com/cbeer/solr_wrapper', branch: 'master'
+  #gem 'solr_wrapper', '>= 0.3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/cbeer/solr_wrapper
+  revision: 55910f63ca58cf7cdc1ab0ec3bb75ace22bbe1ba
+  branch: master
+  specs:
+    solr_wrapper (1.2.0)
+      faraday
+      retriable
+      ruby-progressbar
+      rubyzip
+
+GIT
   remote: https://github.com/projecthydra/hydra-editor
   revision: c1e9d298c823567ea68cd6aa200848e47f1b25f0
   ref: c1e9d298
@@ -1154,11 +1165,6 @@ GEM
     slackistrano (3.8.2)
       capistrano (>= 3.8.1)
     slop (4.6.0)
-    solr_wrapper (1.1.0)
-      faraday
-      retriable
-      ruby-progressbar
-      rubyzip
     solrizer (3.4.1)
       activesupport
       daemons
@@ -1338,7 +1344,7 @@ DEPENDENCIES
   sinatra (~> 2.0)
   sitemap_generator (~> 6.0)
   slackistrano (~> 3.8)
-  solr_wrapper (>= 0.3)
+  solr_wrapper!
   spring
   spring-commands-rspec (~> 1.0.2)
   spring-watcher-listen (~> 2.0.0)

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -6,6 +6,7 @@ instance_dir: tmp/solr-test
      # so we're not downloading it over and over. Make sure it exists.
      FileUtils.mkdir_p("tmp/solr_dist") %>
 download_dir: "tmp/solr_dist"
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/
 collection:
     persist: false
     dir: solr/config


### PR DESCRIPTION
Travis can't pull down solr, so all our tests fail. 

We think this is because apache.org is blocking/rate-limiting travis IPs. 

We think that using a new solr_wrapper `mirror_url` feature may fix. This is a test to see if it will. 

New solr_wrapper mirror_url feature is not yet in a released solr_wrapper, so this branch uses solr_wrapper from git. We'd really like to get a solr_wrapper release with the feature, if using it resolves.