### PR TITLE
Adjustments to the GDPR cookie accept banner

### DIFF
--- a/app/assets/javascripts/accept_cookies_banner.js
+++ b/app/assets/javascripts/accept_cookies_banner.js
@@ -11,7 +11,8 @@ chf.set_up_accept_cookies_banner = function () {
 chf.cookies_already_accepted_by_user = function () {
     return document.cookie.match(/user_accepts_our_cookies=true/) != null;
 }
-chf.user_accepts_our_cookies = function() {
+chf.user_accepts_our_cookies = function(event) {
+    event.preventDefault();
     document.cookie = "user_accepts_our_cookies=true; path=/"
     jQuery('.accept_cookies_banner_nav').fadeOut(1000);
 }

--- a/app/assets/stylesheets/local/footer.scss
+++ b/app/assets/stylesheets/local/footer.scss
@@ -129,6 +129,8 @@ body {
 
 $accept_cookies_banner_container_height: 45px;
 nav.accept_cookies_banner_nav {
+  min-height: 1px;
+  background-color: white;
   border: 0px;
   display: none;
   div#accept_cookies_banner_container {
@@ -146,13 +148,14 @@ nav.accept_cookies_banner_nav {
     }
     a.i-accept-link {
       display: block;
-      height: $accept_cookies_banner_container_height;
+      height: $accept_cookies_banner_container_height + 1;
       width: 100%;
       border: 0px;
       padding-top: 12px;
       white-space: nowrap;
       color: white;
-      background-color: $brand-blue;
+      background-color: $brand-red;
+      &:hover { background-color: $brand-blue; }
       text-decoration: none;
       font-size: .9em;
       font-weight: 700;


### PR DESCRIPTION
- Changing accept button colors (basic color is brand red and hover color is brand blue)
- Increasing height of accept button
- adding event.prevent default to cookie accept js function
- setting bottom nav color to white (might later set it to off-white.)