### PR TITLE
Remove sqlite dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ cache:
     - $HOME/.phantomjs
 before_script:
   - jdk_switcher use oraclejdk8
+  - psql -c 'create database scihist_sufia_test;' -U postgres
+  -
 # We need redis even in test due to sufia/curation_concerns
 # use of redlock gem in some internals.
 services:
   - redis-server
+  - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,6 @@ end
 group :development, :test, :profile do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry-byebug'
-  gem 'sqlite3'
   # Access an IRB console on exception pages or by using <%= console %> in views
   #gem 'web-console', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1197,7 +1197,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     sshkit (1.14.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -1359,7 +1358,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec (~> 1.0.2)
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   sufia (= 7.4.0)
   therubyracer
   tty-command

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ rake sufia:default_admin_set:create
      email/password, and create 6 sample works (5 public one private) attached to that account.
   * `./bin/rake dev:data` will create the same 6 sample works, but each belonging to a different
     newly created random user.
-  * Add a default workflow into your test database so the 'edit' view of the sample works won't throw an error:
-```
-$ cd db
-$ sqlite3 -separator $'\t' -header development.sqlite3 "insert into sipity_workflows values (1, 'default', 'Default workflow', 'A single submission step, default workflow', '','' , 't');"
-```
 
 ### Running tests locally
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,24 +5,28 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: scihist_sufia_dev
+
 profile:
   <<: *default
-  database: db/development.sqlite3
+  database: scihist_sufia_dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: scihist_sufia_test
 
+# Actual production values are not in this repo file, but in case you want to run
+# your dev copy in production mode, we'll just use the dev db.
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: scihist_sufia_dev


### PR DESCRIPTION
The "bundle install" command should no longer need to install sqlite, since we're no longer using it in development, staging, or production.