### PR TITLE
Tweak the orphaned fixity check cleanup script

### DIFF
--- a/lib/tasks/clean_up_orphaned_fixity_records.rake
+++ b/lib/tasks/clean_up_orphaned_fixity_records.rake
@@ -42,7 +42,7 @@ end
 def item_exists_in_fedora?(file_set_id)
   begin
     FileSet.find(file_set_id) != nil
-  rescue ActiveFedora::ObjectNotFoundError
+  rescue ActiveFedora::ObjectNotFoundError, Ldp::Gone
     false
   end
 end


### PR DESCRIPTION
Adding Ldp::Gone to list of exceptions to catch in identifying vanished FileSets.
Two different exceptions get thrown depending on whether a placeholder is left when a FileSet is deleted. We want to delete the fixity check records in either case.