### PR TITLE
Fix bug with batch ingest with formats selected

### DIFF
--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -37,10 +37,9 @@ class BatchCreateJob < ActiveJob::Base
     def create_uploaded_files(titles, resource_types, attributes, uploaded_files = [])
       uploaded_files.each do |upload_id|
         title = [titles[upload_id]] if titles[upload_id]
-        resource_type = [resource_types[upload_id]] if resource_types[upload_id]
         attributes = attributes.merge(uploaded_files: [upload_id],
                                       title: title,
-                                      resource_type: resource_type)
+                                      resource_type: resource_types[upload_id])
         model = model_to_create(attributes)
         child_log = CurationConcerns::Operation.create!(user: user,
                                                         operation_type: "Create Work",


### PR DESCRIPTION
Closes #1114

Our code was wrapping an extra array where it shouldn't have, not sure why, something lost in translation of copying and customizing sufia code.

In testing period, nobody tested batch upload of _local_ files with 'formats' selected, which is the only time it would occur.