### PR TITLE
Tweaks to the "Recent Items" feature.

### DIFF
--- a/app/helpers/recent_items_helper.rb
+++ b/app/helpers/recent_items_helper.rb
@@ -12,7 +12,7 @@ module RecentItemsHelper
       @how_many_works_to_show = 6
       @how_often_to_change = 60 * 10 # ten minutes
       #@how_often_to_change = 5 # useful for testing in the terminal
-      @how_many_works_in_bag = 15
+      @how_many_works_in_bag = 50
     end
 
     def recent_items()


### PR DESCRIPTION
Recent Items has been live for a couple weeks now.
- To make the selection more interesting, we're increasing the size of the bag from which recent items candidates are picked at random. Was 15; is now 50.
- Any other suggestions for adjustments or fixes welcome.