### PR TITLE
accept cookie banner in capybara test

### DIFF
--- a/spec/features/search_feature_spec.rb
+++ b/spec/features/search_feature_spec.rb
@@ -22,6 +22,12 @@ RSpec.feature "Search smoke-tests", js: true do
   shared_examples "searching" do
     scenario "searching" do
       visit(root_path)
+
+      # Get cookie banner out of the way if it's present
+      if has_link?('I Accept')
+        click_link('I Accept')
+      end
+
       fill_in 'q', with: 'two'
       click_button 'Search'
 


### PR DESCRIPTION
for some reason only fails on travis, where the cookie banner is getting in the way:

Firing a click at co-ordinates [386, 701] failed. Poltergeist detected another element with CSS selector 'html.fixedsticky-withoutfixedfixed body.localized-layout.branded-body-font nav.navbar.navbar-default.navbar-fixed-bottom.accept_cookies_banner_nav div#accept_cookies_banner_container.container-fluid div.row div#accept_cookies_copy.col-sm-10.i-accept-copy' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').