### PR TITLE
use princeton mirror url for downloading solr in test

### DIFF
--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -11,3 +11,6 @@ collection:
     dir: solr/config
     name: hydra-test
 version: 6.3.0
+# Attempt to use mirror url to keep travis tests from being blocked by
+# apache for too many solr downloads.
+mirror_url: http://lib-solr-mirror.princeton.edu/dist/


### PR DESCRIPTION
Our travis builds are failing with network errors again trying to download solr. Will this fix it?