### PR TITLE
Extra blacklight validation

### DIFF
--- a/app/controllers/collections_show_controller.rb
+++ b/app/controllers/collections_show_controller.rb
@@ -23,6 +23,10 @@ class CollectionsShowController < CatalogController
   # so :id can continue being our parent collection id.
   # displays values and pagination links for a single facet field
   def facet
+    unless params.key?(:facet_id)
+      redirect_back fallback_location: { action: "index", id: params['id'] }
+      return
+    end
     @facet = blacklight_config.facet_fields[params[:facet_id]]
     @response = get_facet_field_response(@facet.key, params)
     @display_facet = @response.aggregations[@facet.key]
@@ -34,6 +38,14 @@ class CollectionsShowController < CatalogController
       # Draw the partial for the "more" facet modal window:
       format.js { render :layout => false }
     end
+  end
+
+  def range_limit
+    unless params.key?('range_field')
+      redirect_back fallback_location: collection_url
+      return
+    end
+    super
   end
 
   # catalog controller action method we don't want to expose

--- a/app/controllers/collections_show_controller.rb
+++ b/app/controllers/collections_show_controller.rb
@@ -24,7 +24,7 @@ class CollectionsShowController < CatalogController
   # displays values and pagination links for a single facet field
   def facet
     unless params.key?(:facet_id)
-      redirect_back fallback_location: { action: "index", id: params['id'] }
+      redirect_back fallback_location: { action: "index", id: params[:id] }
       return
     end
     @facet = blacklight_config.facet_fields[params[:facet_id]]
@@ -42,7 +42,7 @@ class CollectionsShowController < CatalogController
 
   def range_limit
     unless params.key?('range_field')
-      redirect_back fallback_location: collection_url
+      redirect_back fallback_location: collection_path(params[:id])
       return
     end
     super


### PR DESCRIPTION
These tweaks avoid two recent errors we've gotten in production by checking search inputs before they are sent to blacklight_range_limit. Fixes https://github.com/sciencehistory/chf-sufia/issues/1144
Note: I'm also going to suggest a fix to the actual blacklight_range_limit project based on https://github.com/sciencehistory/chf-sufia/pull/1126 .