### PR TITLE
Adding an expiration date for the GPDR cookie.

### DIFF
--- a/app/assets/javascripts/accept_cookies_banner.js
+++ b/app/assets/javascripts/accept_cookies_banner.js
@@ -15,7 +15,11 @@ chf.cookies_already_accepted_by_user = function () {
 }
 chf.user_accepts_our_cookies = function(event) {
     event.preventDefault();
-    document.cookie = "user_accepts_our_cookies=true; path=/"
+    var expiraton_str = new Date(new Date()
+        .setFullYear(new Date()
+        .getFullYear() + 3))
+        .toString();
+    document.cookie = "user_accepts_our_cookies=true; path=/; expires=" + expiraton_str
     jQuery('.accept_cookies_banner_nav').fadeOut(1000);
 }
 chf.user_does_not_accept_our_cookies = function() {

--- a/config/application.rb
+++ b/config/application.rb
@@ -223,7 +223,7 @@ module Chufia
     # Show the GDPR "I accept" cookies banner by default.
     # This setting is overridden in test.rb,
     # so the tests don't have to click "I accept".)
-    config.hide_accept_cookies_banner = true
+    config.hide_accept_cookies_banner = false
 
     def log_error(error)
       Honeybadger.notify(error)


### PR DESCRIPTION
 Also fixing a bug in https://github.com/sciencehistory/chf-sufia/pull/1143 bug. We want to show the GDPR banner by default in dev and production, and hide it from the unit tests. See the note at https://github.com/sciencehistory/chf-sufia/pull/1143/files#r216418234 .

Fixes https://github.com/sciencehistory/chf-sufia/issues/1154 .