### PR TITLE
Remove solr_wrapper mirror_url setting.

### DIFF
--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -11,6 +11,11 @@ collection:
     dir: solr/config
     name: hydra-test
 version: 6.3.0
+
+
 # Attempt to use mirror url to keep travis tests from being blocked by
 # apache for too many solr downloads.
-mirror_url: http://lib-solr-mirror.princeton.edu/dist/
+# (Commenting this out, as it was more trouble than it was worth. See 
+# https://github.com/sciencehistory/chf-sufia/pull/1153
+# for more details.)
+# mirror_url: http://lib-solr-mirror.princeton.edu/dist/


### PR DESCRIPTION
To avoid having to monkey patch solr_wrapper, as detailed in https://github.com/sciencehistory/chf-sufia/pull/1153/ , we're simply avoiding using the Princeton mirror for solr.