### PR TITLE
update ffi gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.18)
+    ffi (1.9.25)
     flipflop (2.3.1)
       activesupport (>= 4.0)
     flot-rails (0.0.7)


### PR DESCRIPTION
avoids warning on CVE-2018-1000201, which doesn't really apply to us anyway cause we're not on windows