### PR TITLE
Get solr from s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ services:
   - postgresql
 
 env:
-  matrix:
-  - secure: P/iCE9cJn62iR9zHzHpCnT9a5cizKS7ASBxs7vM2OPKkc335Dxm4VxzejEFmVOqWAT//utGzLI6MGLYkqFwYIZznB6oJucEIz5Xp+ABOX6ZWMN3bueU2BILiRW9AVWWZVH+19KXSOQVqh1dz55Cv8J8iwUHfXdZCmdOoli5TzAI=
-  - secure: m7YZobFsjitZ5PLKKWEYEopNBRku5ot8St4HA3o2/t/PEgQrep74/+01Styl5RHb8ZAbFCM6hgt4asQczsujEF86+65NW3AKEpjcgL4zQ1+98Dd3+qApwh5JGgiwu2u31noQ6x/PfLO4k6E0vMtshfni91WDGPXsLZRP/3hzPns=
+  global:
+  - secure: Nom1EhdruXCCqnP2TncEJnq/iVfF9vMTIdtwgi+9MqEJVNM+yFcZ+gmU4GbVLwIaW06L+AjSDKgf6NbZMhkf05aJLEGSFwCRK8KQy0ZGrzAM/KuhirNQP5HSnX15XL3hmZwIPmBq7DoF1o6LgyyQ5Xey+JbepTZt/WMk3wo0VD4=
+  - secure: P0g6AmpNHLG/l57KzgHBjCMRiqk45T1bC4HRTxcwuRnZn1EiniEjp7ratFyb9LqxLkM+RkbB31YHWdmiYT16HyNNoTLA9r7B7oXh9fIi++2pqg7wEK8aBB286Zj/4b5lQxQPxMVhbkUtEY1ocw56SpU1YJOHPVkb+/8FCdturwc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ before_script:
 services:
   - redis-server
   - postgresql
+
+env:
+  matrix:
+  - secure: P/iCE9cJn62iR9zHzHpCnT9a5cizKS7ASBxs7vM2OPKkc335Dxm4VxzejEFmVOqWAT//utGzLI6MGLYkqFwYIZznB6oJucEIz5Xp+ABOX6ZWMN3bueU2BILiRW9AVWWZVH+19KXSOQVqh1dz55Cv8J8iwUHfXdZCmdOoli5TzAI=
+  - secure: m7YZobFsjitZ5PLKKWEYEopNBRku5ot8St4HA3o2/t/PEgQrep74/+01Styl5RHb8ZAbFCM6hgt4asQczsujEF86+65NW3AKEpjcgL4zQ1+98Dd3+qApwh5JGgiwu2u31noQ6x/PfLO4k6E0vMtshfni91WDGPXsLZRP/3hzPns=

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -15,7 +15,10 @@ version: 6.3.0
 
 # Attempt to use mirror url to keep travis tests from being blocked by
 # apache for too many solr downloads.
-# (Commenting this out, as it was more trouble than it was worth. See 
+# (Commenting this out, as it was more trouble than it was worth. See
 # https://github.com/sciencehistory/chf-sufia/pull/1153
 # for more details.)
 # mirror_url: http://lib-solr-mirror.princeton.edu/dist/
+
+url: https://s3.amazonaws.com/science-history-build-cache/solr/6.3.0/solr-6.3.0.zip
+validate: false

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -13,12 +13,15 @@ collection:
 version: 6.3.0
 
 
-# Attempt to use mirror url to keep travis tests from being blocked by
-# apache for too many solr downloads.
-# (Commenting this out, as it was more trouble than it was worth. See
-# https://github.com/sciencehistory/chf-sufia/pull/1153
-# for more details.)
-# mirror_url: http://lib-solr-mirror.princeton.edu/dist/
-
-url: https://s3.amazonaws.com/science-history-build-cache/solr/6.3.0/solr-6.3.0.zip
+# This signed URL makes use of two env variables defined in .travis.yml:
+# - AWS_ACCESS_KEY_ID_FOR_SOLR=[secure]
+# - AWS_SECRET_ACCESS_KEY_FOR_SOLR=[secure]
+# Since we're downloading directly from our own S3 bucket, no need to validate:
 validate: false
+
+<% require 'aws-sdk-s3'
+  s3 = Aws::S3::Client.new( region: 'us-east-1', access_key_id:  ENV['AWS_ACCESS_KEY_ID_FOR_SOLR'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY_FOR_SOLR'] )
+  signer = Aws::S3::Presigner.new(client: s3) %>
+url: '<%= signer.presigned_url( :get_object, bucket: 'science-history-build-cache', key: "solr-6.3.0.tgz" ) %>'
+
+solr_zip_path: 'tmp/solr-6.3.0.zip'


### PR DESCRIPTION
Fixes #1163 .
Daniel created an S3 account (travis) which can only LIST and GET objects from the science-history-build-cache bucket.
We declare two env variables in .travis.yml that define AWS credentials for that account, and set the solr zip download url explicitly in solr_wrapper_test.yml .
We also set validate to false.