### PR TITLE
WIP Use no-redirect content url for Tumblr.

### DIFF
--- a/app/views/curation_concerns/base/_social_media.html.erb
+++ b/app/views/curation_concerns/base/_social_media.html.erb
@@ -23,16 +23,6 @@
     default_page_title
   end
 end %>
-
-<%
-  #HACK
-  #TODO: RENAME AND REFACTOR.
-  #This is just a proof of concept.
-  new_tumblr_url = member_src_attributes(member: presenter, size_key: :large )[:src]
-  #END HACK
- %>
-
-
 <% share_url ||= presenter ?  polymorphic_url([main_app, presenter]) : request.original_url %>
 <% share_media ||= presenter ? social_media_share_image_medium(presenter) : nil %>
 <% share_presenter_description ||= presenter.short_plain_description if (presenter && presenter.respond_to?(:short_plain_description)) %>
@@ -86,7 +76,7 @@ end %>
 
   <!-- Sharingbutton Tumblr -->
   <%# see https://www.tumblr.com/docs/en/share_button %>
-  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{posttype: 'photo', content: new_tumblr_url, caption: title_plus_description, canonicalUrl: share_url, shareSource: 'tumblr_share_button'}.to_param}",
+  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{content: share_media, caption: title_plus_description, canonicalUrl: share_url, shareSource: 'tumblr_share_button'}.to_param}",
               class: 'social-media-link tumblr btn btn-brand-dark',
               target: '_blank',
               rel: 'noopener noreferrer',

--- a/app/views/curation_concerns/base/_social_media.html.erb
+++ b/app/views/curation_concerns/base/_social_media.html.erb
@@ -23,6 +23,16 @@
     default_page_title
   end
 end %>
+
+<%
+  #HACK
+  #TODO: RENAME AND REFACTOR.
+  #This is just a proof of concept.
+  new_tumblr_url = member_src_attributes(member: presenter, size_key: :large )[:src]
+  #END HACK
+ %>
+
+
 <% share_url ||= presenter ?  polymorphic_url([main_app, presenter]) : request.original_url %>
 <% share_media ||= presenter ? social_media_share_image_medium(presenter) : nil %>
 <% share_presenter_description ||= presenter.short_plain_description if (presenter && presenter.respond_to?(:short_plain_description)) %>
@@ -76,7 +86,7 @@ end %>
 
   <!-- Sharingbutton Tumblr -->
   <%# see https://www.tumblr.com/docs/en/share_button %>
-  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{posttype: 'photo', content: share_media, caption: title_plus_description, canonicalUrl: share_url, shareSource: 'tumblr_share_button'}.to_param}",
+  <%= link_to "https://www.tumblr.com/widgets/share/tool?#{{posttype: 'photo', content: new_tumblr_url, caption: title_plus_description, canonicalUrl: share_url, shareSource: 'tumblr_share_button'}.to_param}",
               class: 'social-media-link tumblr btn btn-brand-dark',
               target: '_blank',
               rel: 'noopener noreferrer',


### PR DESCRIPTION
The Tumblr button, as currently implemented in production, apparently doesn't follow redirects in "content" urls, as currently in prod. My first attempt was to send a direct link to s3 instead. We gave this some thought and it didn't seem like a great idea in the long run.

I also discovered by accident that removing the "posttype: 'photo'" section of the share tool link fixes the problem: for some odd reason, when you omit that part of the link, Tumblr follows the redirect. Note that @jrochkind [specifically added the posttype in response to stakeholder request back in April](https://github.com/sciencehistory/chf-sufia/pull/1037), so we may or may not want to backtrack on an existing feature.

As of Tuesday this second fix is available for testing [in staging](https://staging.digital.sciencehistory.org/works/bc386j260). I'm going to wait until @HKativa gets back to do any more work on this, as I'm not that familiar with how Othermeralia uses our content (much less other users in the wild). 