### PR TITLE
update logger to a non-yanked version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,7 +486,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     little-plugger (1.1.4)
-    logger (1.2.8)
+    logger (1.3.0)
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)


### PR DESCRIPTION
https://github.com/nahi/logger/issues/3

This is just the result of running `bundle update --conservative logger`.

Based on above issue, I _think_ 1.3.0 is equivalent to 1.2.8 that we were using before, now yanked.

This comes up only because our `jettywrapper` dependency has an explicit dependency on `logger`. `Logger` is a part of stdlib, and doens't really need an explicit dependency. But it was also released as a separate gem to rubygems -- perhaps accidentally?  Perhaps @nahi trying to clean that up after 7 years is why it was yanked?  I don't entirely understand what was going on, but the yanking of 1.2.8 will cause a problem for anyone that has an explicit `logger` dependency in their dependency tree, as we did/do.  We have no easy way to remove the explicit dependency, unless we stop using `jettywrapper`, which I'm not sure if we can or not.

Easiest fix to make the app deployable and buildable again seems to be this.