### PR TITLE
Adding a target=_blank to description links

### DIFF
--- a/app/helpers/description_formatter_helper.rb
+++ b/app/helpers/description_formatter_helper.rb
@@ -3,20 +3,25 @@ module DescriptionFormatterHelper
   def format_description(text, truncate: false)
     # sanitize. should have been sanitized on input, but just to
     # be safe.
-    text = DescriptionSanitizer.new.sanitize(text).html_safe
+    text = DescriptionSanitizer.new(add_target_blank: true).sanitize(text).html_safe
 
     # truncate, may contain HTML
     if truncate
       text = HtmlAwareTruncation.truncate_html(text, length: 220, separator: /\s/)
     end
 
-    # And convert line breaks to paragraphs
-    text = simple_format(text)
+    # And convert line breaks to paragraphs. Don't need to sanitize, we
+    # already did.
+    text = simple_format(text, {}, sanitize: false)
 
-    # a sufia helper to turn URLs into links.
-    text = iconify_auto_link(text)
-
-    text = add_target_blank(text)
+    # Extracted from sufia helper `text = iconify_auto_link(text), a sufia helper to turn URLs
+    # into links. But we want to turn off sanitization, cause we're already sanitizing how we
+    # want previously. `auto_link` comes from `rails_autolink` gem, and it's possible we don't
+    # really need it in our chf_sufia app at all we just inherited it from sufia, but we'll
+    # leave it for now.
+    text= auto_link(text, sanitize: false) do |value|
+        "<span class='glyphicon glyphicon-new-window'></span>#{('&nbsp;' + value) if show_link}"
+    end.html_safe
 
     text
   end
@@ -30,15 +35,6 @@ module DescriptionFormatterHelper
     end
 
     format_description(text, truncate: true)
-  end
-
-
-  def add_target_blank(html)
-    doc = Nokogiri::HTML.fragment(html)
-    doc.css('a').each do |link|
-      link['target'] = '_blank'
-    end
-    doc.to_s.html_safe
   end
 
 

--- a/app/helpers/description_formatter_helper.rb
+++ b/app/helpers/description_formatter_helper.rb
@@ -16,6 +16,8 @@ module DescriptionFormatterHelper
     # a sufia helper to turn URLs into links.
     text = iconify_auto_link(text)
 
+    text = add_target_blank(text)
+
     text
   end
 
@@ -29,4 +31,15 @@ module DescriptionFormatterHelper
 
     format_description(text, truncate: true)
   end
+
+
+  def add_target_blank(html)
+    doc = Nokogiri::HTML.fragment(html)
+    doc.css('a').each do |link|
+      link['target'] = '_blank'
+    end
+    doc.to_s.html_safe
+  end
+
+
 end

--- a/app/views/collections/_collection_description.erb
+++ b/app/views/collections/_collection_description.erb
@@ -1,5 +1,5 @@
 <% presenter.description.each do |description| %>
     <p class="collection_description">
-        <%= iconify_auto_link(format_description(description)) %>
+        <%=format_description(description)%>
     </p>
 <% end %>

--- a/app/views/curation_concerns/base/_work_description.html.erb
+++ b/app/views/curation_concerns/base/_work_description.html.erb
@@ -1,5 +1,5 @@
 <div class="work_description">
   <% presenter.description.each do |description| %>
-    <%= format_description(description) %>
+    <%=format_description(description) %>
   <% end %>
 </div>

--- a/spec/features/collection_feature_spec.rb
+++ b/spec/features/collection_feature_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Collections", js: true do
   let!(:work) { FactoryGirl.create(:work, :with_complete_metadata, title: [title], subject: [subject]) }
   let!(:collection) { FactoryGirl.create(
     :collection, :public, :with_image, members: [work],
-    description: ['See also <a href="https://en.wikipedia.org" target="_blank">Wikipedia</a>.'])
+    description: ['See also <a href="https://en.wikipedia.org">Wikipedia</a>.'])
   }
 
   scenario "displays collection with item, searches" do
@@ -20,11 +20,12 @@ RSpec.feature "Collections", js: true do
     expect(page).to have_text("1 item")
     expect(page).to have_link(title, href: curation_concerns_generic_work_path(work.id))
 
-    # The scrubber invoked in app/views/collections/_collection_description.erb
-    # is supposed to allow the link, but scrub the 'target' attribute.
+    # The description formatter (in app/helpers/description_formatter_helper.rb)
+    # adds a 'target' attribute to all links on collections.
+    # (See https://github.com/sciencehistory/chf-sufia/pull/1196/)
 
     expect(page).to have_link('Wikipedia', href: 'https://en.wikipedia.org')
-    expect(page.find_link('Wikipedia')[:target]).to eq('')
+    expect(page.find_link('Wikipedia')[:target]).to eq('_blank')
 
     # Could not get test of facet search functionality to work reliably on Travis, it was
     # flaky, seemed to be on waiting for the page transition to actually show facet results,


### PR DESCRIPTION
Uses nokogiri to add in the new link attribute.
Note that the target=_blank is not stored, but added at display time; the tests reflect this.
Fixes #1183