### PR TITLE
Fixing typo w/ description sanitizer

### DIFF
--- a/app/sanitizers/description_sanitizer.rb
+++ b/app/sanitizers/description_sanitizer.rb
@@ -22,7 +22,7 @@ class DescriptionSanitizer < Rails::Html::Sanitizer
     end
 
     @link_blank_target_scrubber = Loofah::Scrubber.new do |node|
-      if node.name = "a"
+      if node.name == "a"
         node['target'] = '_blank'
       end
     end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -12,10 +12,26 @@ RSpec.describe CollectionsController,  type: :controller do
     collection_params = {
       "collection"=>{
         "title"=>["title"],
-        "description"=>["<a href=\"https://www.nytimes.com\" target=\"_blank\">The New York Times.</a>"]
+        "description"=>["""<a href=\"https://www.nytimes.com\" target=\"_blank\">The New York Times.</a>
+          <i>italics</i>
+          <b>bold</b>
+          <cite>citation</cite>
+          <goat>this tag should not make it, except for its contents</goat>
+          <i>and this tag should get closed."""
+        ]
       }
     }
     post :create, params: collection_params
-    expect(Collection.first.description.first).to eq "<a href=\"https://www.nytimes.com\">The New York Times.</a>"
+
+
+    result = Collection.first.description.first
+    expect(result).to include("<a href=\"https://www.nytimes.com\">The New York Times.</a>")
+    expect(result).to include("<i>italics</i>")
+    expect(result).to include("<b>bold</b>")
+    expect(result).not_to include("goat")
+    expect(result).to include("this tag should not make it, except for its contents")
+    expect(result).to include("<cite>citation</cite>")
+    expect(result).to include("<i>and this tag should get closed.</i>")
+
   end
 end

--- a/spec/features/collection_feature_spec.rb
+++ b/spec/features/collection_feature_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Collections", js: true do
   let!(:work) { FactoryGirl.create(:work, :with_complete_metadata, title: [title], subject: [subject]) }
   let!(:collection) { FactoryGirl.create(
     :collection, :public, :with_image, members: [work],
-    description: ['See also <a href="https://en.wikipedia.org">Wikipedia</a>.'])
+    description: ['See also <a href="https://en.wikipedia.org">Wikipedia</a>. <i>italics</i> <b>bold</b> <cite>citation</cite>'])
   }
 
   scenario "displays collection with item, searches" do
@@ -26,6 +26,10 @@ RSpec.feature "Collections", js: true do
 
     expect(page).to have_link('Wikipedia', href: 'https://en.wikipedia.org')
     expect(page.find_link('Wikipedia')[:target]).to eq('_blank')
+
+    expect(page).to have_css("i",    :text => "italics")
+    expect(page).to have_css("b",    :text => "bold")
+    expect(page).to have_css("cite", :text => "citation")
 
     # Could not get test of facet search functionality to work reliably on Travis, it was
     # flaky, seemed to be on waiting for the page transition to actually show facet results,


### PR DESCRIPTION
'==' != '='