### PR TITLE
Travis: Remove unused directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 script: bundle exec rake dev:spec_with_app_load
 rvm:
   - 2.5.1


### PR DESCRIPTION
This PR removes a now-unused setting from Travis config.

  - `[ci skip]`, since it's just configuration.