### PR TITLE
"Project" metadata field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -121,6 +121,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("rights", :facetable), helper_method: :license_label, label: "Rights", limit: 5
     config.add_facet_field solr_name("division", :facetable), label: "Department", limit: 5
     config.add_facet_field solr_name("exhibition", :facetable), label: "Exhibition", limit: 5
+    config.add_facet_field solr_name("project", :facetable), label: "Project", limit: 5
     config.add_facet_field "visibility_ssi", label: "Visibility (Staff-only)", show: :current_user, helper_method: :visibility_facet_labels
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -43,6 +43,7 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
     :place_of_publication,
     :place_of_creation,
     :exhibition,
+    :project,
     :source,
     :genre_string,
     :medium,

--- a/app/forms/batch_upload_form.rb
+++ b/app/forms/batch_upload_form.rb
@@ -16,6 +16,7 @@ class BatchUploadForm < Sufia::Forms::BatchUploadForm
       :subject,
       :division,
       :exhibition,
+      :project,
       :source,
       :series_arrangement,
       :physical_container,

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -23,6 +23,7 @@ module CurationConcerns
         :subject,
         :division,
         :exhibition,
+        :project,
         :source,
         :series_arrangement,
         :physical_container,

--- a/app/models/concerns/generic_metadata.rb
+++ b/app/models/concerns/generic_metadata.rb
@@ -144,6 +144,10 @@ module GenericMetadata
       index.as :stored_searchable, :facetable
     end
 
+    property :project, predicate: ::RDF::URI.new("http://opaquenamespace.org/ns/project") do |index|
+      index.as :stored_searchable, :facetable
+    end
+
     property :source, predicate: ::RDF::URI.new("http://purl.org/dc/elements/1.1/source") do |index|
       index.as :stored_searchable
     end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -106,6 +106,9 @@ class SolrDocument
   def exhibition
     self[Solrizer.solr_name('exhibition')]
   end
+  def project
+    self[Solrizer.solr_name('project')]
+  end
   def source
     self[Solrizer.solr_name('source')]
   end

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -14,7 +14,7 @@ module CurationConcerns
       :artist, :attributed_to, :author, :addressee, :interviewee, :interviewer,
       :manufacturer, :manner_of, :photographer, :place_of_interview,
       :place_of_manufacture, :place_of_creation, :place_of_publication,
-      :extent, :division, :exhibition, :source, :series_arrangement, :rights_holder,
+      :extent, :division, :exhibition, :project, :source, :series_arrangement, :rights_holder,
       :credit_line, :additional_credit, :file_creator, :admin_note,
       :inscription, :date_of_work, :editor, :engraver, :printer,
       :printer_of_plates, :after, :thumbnail_path,

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -30,6 +30,7 @@
 <%= presenter.attribute_to_html(:subject, render_as: :faceted ) %>
 <%= presenter.attribute_to_html(:division, label: "Department", render_as: :faceted) %>
 <%= presenter.attribute_to_html(:exhibition) %>
+<%= presenter.attribute_to_html(:project) %>
 <%= presenter.attribute_to_html(:series_arrangement) %>
 <%# TODO: , render_as: :physical_container %>
 <%= presenter.attribute_to_html(:physical_container) %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -164,6 +164,7 @@
         <%= @presenter.attribute_to_html(:division, label: "Department", render_as: :faceted) %>
         <%= @presenter.attribute_to_html(:exhibition, render_as: :faceted) %>
 
+
         <% if @presenter.in_collection_presenters.present? %>
           <tr>
             <th>Collection</th>
@@ -175,6 +176,8 @@
               </ul>
             </td>
         <% end %>
+
+        <%= @presenter.attribute_to_html(:project, render_as: :faceted) %>
 
         <%= @presenter.attribute_to_html(:series_arrangement) %>
         <%= @presenter.attribute_to_html(:physical_container) %>

--- a/app/views/records/edit_fields/_project.html.erb
+++ b/app/views/records/edit_fields/_project.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :project, as: :multi_value_select_local,
+  include_blank: true, options: Rails.configuration.projects,
+  value_method: :to_s, label_method: :to_s
+%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -110,6 +110,19 @@ module Chufia
       'Library',
     ]
 
+    config.projects = [
+      'Atmospheric Science',
+      'Chemical History of Electronics',
+      "Imagining Philadelphia's Energy Futures",
+      'Mass Spectrometry',
+      'Nanotechnology',
+      'Oral History of the Toxic Substances Control Act',
+      'Pew Biomedical Scholars',
+      'REACH Ambler',
+      'Scientific and Technical Information Systems',
+      'Science and Disability',
+    ]
+
     config.file_creators = [
       'Brown, Will',
       'Center for Oral History',

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -38,7 +38,7 @@ en:
         subject: "Topical terms describing the “aboutness” of the work. Depicted persons, places, and time periods are covered here as well. Field supports FAST (derived from Library of Congress authorities) autocomplete. <strong><em>Ex: • Alchemy • Integrated circuits</strong></em>. Recommended."
         division: "Select the CHF administrative entity responsible for the management and curation of the physical work. Required."
         exhibition: "Select any current or past Museum exhibition(s) that the work has been displayed in, if applicable. If a desired entry is not available, contact the Digital Projects and Metadata Librarian."
-        project: "Project metadata instructions (TBD)"
+        project: "Select any current or past projects that the work is a part of, if applicable. If a desired entry is not available, contact the Digital Projects and Metadata Librarian."
         source: "For standalone digitization from a larger work, use for the name of the work from which the described material is derived. Can be left blank if the digital object is related to its parent work in the repository."
         series_arrangement: "Archival materials only: specify series and subseries of work, where relevant. Capture the information as listed in the finding aid."
         physical_container: "For archival and serialized materials: specify either box/folder or volume/part numbers, where relevant. For library manuscripts, specify shelfmark."

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -38,6 +38,7 @@ en:
         subject: "Topical terms describing the “aboutness” of the work. Depicted persons, places, and time periods are covered here as well. Field supports FAST (derived from Library of Congress authorities) autocomplete. <strong><em>Ex: • Alchemy • Integrated circuits</strong></em>. Recommended."
         division: "Select the CHF administrative entity responsible for the management and curation of the physical work. Required."
         exhibition: "Select any current or past Museum exhibition(s) that the work has been displayed in, if applicable. If a desired entry is not available, contact the Digital Projects and Metadata Librarian."
+        project: "Project metadata instructions (TBD)"
         source: "For standalone digitization from a larger work, use for the name of the work from which the described material is derived. Can be left blank if the digital object is related to its parent work in the repository."
         series_arrangement: "Archival materials only: specify series and subseries of work, where relevant. Capture the information as listed in the finding aid."
         physical_container: "For archival and serialized materials: specify either box/folder or volume/part numbers, where relevant. For library manuscripts, specify shelfmark."

--- a/spec/exporters/collection_exporter_spec.rb
+++ b/spec/exporters/collection_exporter_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CollectionExporter do
+  context "Import collection" do
+    # empty for now.
+  end
+end

--- a/spec/exporters/file_set_exporter_spec.rb
+++ b/spec/exporters/file_set_exporter_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FileSetExporter do
+  # empty for now.
+end

--- a/spec/exporters/generic_work_exporter_spec.rb
+++ b/spec/exporters/generic_work_exporter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GenericWorkExporter do
     "photographer" => ["Bruce McMillan"],
     "publisher" => ["publishing house"],
     "credit_line" => ["Courtesy of Science History Institute"],
-    "project" => ["Mass Spectrometry", "Nanotechnology"],
+    "project" => ["Nanotechnology", "Mass Spectrometry"],
     "physical_container" => "b2000|f3|v4|p5|g234|sMS 13",
     "access_control_id" => "b14df645-5a06-40e8-826a-43579fe6cfed",
     "date_of_work_ids" => ["63f04166-8712-4667-9f33-8ed9c0d68402",
@@ -107,14 +107,20 @@ RSpec.describe GenericWorkExporter do
   end #let :expected_export_hash
 
   it "exports" do
-    x = GenericWorkExporter.new(work)
-    actual_hash = x.to_hash
+    actual_hash = GenericWorkExporter.new(work).to_hash
     %w(id depositor access_control_id date_of_work_ids inscription_ids additional_credit_ids).each do |k|
       actual_hash.delete(k)
       expected_export_hash.delete(k)
     end
+
+    # Travis hack:
+    # For whatever reason, these two sort lines are only needed to get Travis to pass...
+    actual_hash['project'].sort!
+    expected_export_hash['project'].sort!
+    # end Travis hack
+
     expect(actual_hash).to eq expected_export_hash
-  end
+    end
 
 
   # context "public work" do

--- a/spec/exporters/generic_work_exporter_spec.rb
+++ b/spec/exporters/generic_work_exporter_spec.rb
@@ -1,0 +1,196 @@
+require 'rails_helper'
+
+RSpec.describe GenericWorkExporter do
+  let (:work) do
+    FactoryGirl.create(:generic_work, dates_of_work: []).tap do |w|
+      w.physical_container = "b2000|f3|v4|p5|g234|sMS 13"
+      w.date_of_work_attributes = [{start: "2003", finish: "2015"}, {start:'1200', start_qualifier:'century'}]
+      w.inscription_attributes = [{location: "chapter 7", text: "words"}, {location: "place", text: "stuff"}]
+      w.additional_credit_attributes = [{role: "photographer", name: "Puffins"}, {role: "photographer", name: "Squirrels"}]
+      w.author = ["Bruce McMillan"]
+      w.photographer = ["Bruce McMillan"]
+      w.publisher = ["publishing house"]
+      w.editor = ["the editor"]
+      w.attributed_to = ["presumptive author"]
+      w.engraver = ["engraving professional"]
+      w.project = ['Mass Spectrometry', 'Nanotechnology']
+      w.save
+    end # tap do
+  end # let work
+
+
+  # TODO: investigate why dates and inscriptions appear to contain duplicate material.
+  let (:expected_export_hash) do {
+    "id" => "st74cq441",
+    "depositor" => "user1_72e0@example.com",
+    "title" => ["Test title"],
+    "attributed_to" => ["presumptive author"],
+    "author" => ["Bruce McMillan"],
+    "editor" => ["the editor"],
+    "engraver" => ["engraving professional"],
+    "photographer" => ["Bruce McMillan"],
+    "publisher" => ["publishing house"],
+    "credit_line" => ["Courtesy of Science History Institute"],
+    "project" => ["Mass Spectrometry", "Nanotechnology"],
+    "physical_container" => "b2000|f3|v4|p5|g234|sMS 13",
+    "access_control_id" => "b14df645-5a06-40e8-826a-43579fe6cfed",
+    "date_of_work_ids" => ["63f04166-8712-4667-9f33-8ed9c0d68402",
+      "ce0b6cef-3ab4-4e88-a9c5-de03c36dc51b"
+    ],
+    "inscription_ids" => ["cd66f7d8-8db4-461d-93ca-d5304da47763",
+      "ba4ea153-7a3e-4525-8332-d4cb061f5ff5"
+    ],
+    "additional_credit_ids" => ["472a387e-e872-4c36-a9ce-eb3038744f08",
+      "9aa815ab-53f4-427a-913f-4c3347f96823"
+    ],
+    "access_control" => "public",
+    "dates" => [{
+        "start" => "2003",
+        "finish" => "2015"
+      },
+      {
+        "start" => "1200",
+        "start_qualifier" => "century"
+      },
+      {
+        "start" => "2003",
+        "finish" => "2015"
+      },
+      {
+        "start" => "1200",
+        "start_qualifier" => "century"
+      }
+    ],
+    "inscriptions" => [{
+        "location" => "chapter 7",
+        "text" => "words",
+        "display_label" => "(chapter 7) \"words\""
+      },
+      {
+        "location" => "place",
+        "text" => "stuff",
+        "display_label" => "(place) \"stuff\""
+      },
+      {
+        "location" => "chapter 7",
+        "text" => "words",
+        "display_label" => "(chapter 7) \"words\""
+      },
+      {
+        "location" => "place",
+        "text" => "stuff",
+        "display_label" => "(place) \"stuff\""
+      }
+    ],
+    "additional_credits" => [{
+        "role" => "photographer",
+        "name" => "Puffins",
+        "display_label" => "Photographed by Puffins"
+      },
+      {
+        "role" => "photographer",
+        "name" => "Squirrels",
+        "display_label" => "Photographed by Squirrels"
+      },
+      {
+        "role" => "photographer",
+        "name" => "Puffins",
+        "display_label" => "Photographed by Puffins"
+      },
+      {
+        "role" => "photographer",
+        "name" => "Squirrels",
+        "display_label" => "Photographed by Squirrels"
+      }
+    ]
+    }
+  end #let :expected_export_hash
+
+  it "exports" do
+    x = GenericWorkExporter.new(work)
+    actual_hash = x.to_hash
+    %w(id depositor access_control_id date_of_work_ids inscription_ids additional_credit_ids).each do |k|
+      actual_hash.delete(k)
+      expected_export_hash.delete(k)
+    end
+    expect(actual_hash).to eq expected_export_hash
+  end
+
+
+  # context "public work" do
+  #   let(:metadata) do
+  #     {
+  #       "id"=>"8049g504g",
+  #       "head" => [
+  #         "#<ActiveTriples::Resource:0x0000558a2682fa68>"
+  #       ],
+  #       "tail" => [
+  #         "#<ActiveTriples::Resource:0x0000558a26826030>"
+  #       ],
+  #       "depositor"=> "njoniec@sciencehistory.org",
+  #       "title" => [
+  #         "Adulterations of food; with short processes for their detection."
+  #       ],
+  #       "date_uploaded"=> "2019-02-08T20:45:54+00:00",
+  #       "date_modified"=> "2019-02-08T20:49:43+00:00",
+  #       "state" => "#<ActiveTriples::Resource:0x0000558a2d321088>",
+  #       "part_of" => [
+  #         "#<ActiveTriples::Resource:0x0000558a2681aff0>"
+  #       ],
+  #       "identifier" => [
+  #         "bib-b1075796"
+  #       ],
+  #       "author" => [
+  #         "Atcherley, Rowland J."
+  #       ],
+  #       "credit_line" => [
+  #         "Courtesy of Science History Institute"
+  #       ],
+  #       "division" => "",
+  #       "file_creator" =>  "",
+  #       "physical_container" =>  "",
+  #       "rights_holder" =>  "",
+  #       "access_control_id" =>  "90cb04df-61a7-4d61-84e2-130fc7ddbee3",
+  #       "access_control" => "public",
+  #       "representative_id" =>  "2v23vv55g",
+  #       "thumbnail_id" =>  "2v23vv55g",
+  #       "admin_set_id" =>  "admin_set/default",
+  #       "child_ids" =>  [
+  #         "kp78gh433",
+  #         "1v53jz06w",
+  #         "nk322f35j",
+  #         "0r9674786",
+  #         "6q182m18c",
+  #         "1831cm25h",
+  #         "8623hz81w"
+  #       ]
+  #     }
+  #   end
+
+  #   it "imports as published" do
+  #     generic_work_importer.import
+  #     new_work = Work.first
+
+  #     expect(new_work.published?).to be(true)
+  #   end
+
+  #   describe "with existing item" do
+  #     let!(:existing_item) { FactoryBot.create(:work,
+  #       friendlier_id: metadata["id"],
+  #       title: "old title",
+  #       external_id: { category: "object", value: "old_id"},
+  #       published: false)}
+
+  #     it "imports and updates data" do
+  #       generic_work_importer.import
+
+  #       expect(Work.where(friendlier_id: metadata["id"]).count).to eq(1)
+  #       item = Work.find_by_friendlier_id!(metadata["id"])
+
+  #       expect(item.title).to eq "Adulterations of food; with short processes for their detection."
+  #       expect(item.published?).to be(true)
+  #       expect(item.external_id).to eq([Work::ExternalId.new(category: "bib", value: "b1075796")])
+  #     end
+  #   end
+  # end
+end # describe

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe BatchEditForm do
         :place_of_publication,
         :place_of_creation,
         :exhibition,
+        :project,
         :source,
         :genre_string,
         :medium,

--- a/spec/forms/batch_edit_form_spec.rb
+++ b/spec/forms/batch_edit_form_spec.rb
@@ -2,8 +2,32 @@ require 'rails_helper'
 
 RSpec.describe BatchEditForm do
   let(:model) { GenericWork.new }
-  let(:work1) { FactoryGirl.create :generic_work, title: ["title 1"], language: ['en'], contributor: ['contributor1'], description: ['description1'], rights: ['rights1'], subject: ['subject1'], identifier: ['id1'], related_url: ['related_url1'], visibility: visibility1 }
-  let(:work2) { FactoryGirl.create :generic_work, title: ["title 2"], publisher: ['Rand McNally'], language: ['en'], resource_type: ['bar'], contributor: ['contributor2'], description: ['description2'], rights: ['rights2'], subject: ['subject2'], identifier: ['id2'], related_url: ['related_url2'], visibility: visibility2 }
+  let(:work1) { FactoryGirl.create :generic_work,
+    title: ["title 1"],
+    language: ['en'],
+    contributor: ['contributor1'],
+    description: ['description1'],
+    rights: ['rights1'],
+    subject: ['subject1'],
+    identifier: ['id1'],
+    related_url: ['related_url1'],
+    project: ['Mass Spectrometry', 'Chemical History of Electronics'],
+    visibility: visibility1
+  }
+  let(:work2) { FactoryGirl.create :generic_work,
+    title: ["title 2"],
+    publisher: ['Rand McNally'],
+    language: ['en'],
+    resource_type: ['bar'],
+    contributor: ['contributor2'],
+    description: ['description2'],
+    rights: ['rights2'],
+    subject: ['subject2'],
+    identifier: ['id2'],
+    related_url: ['related_url2'],
+    project: ['Mass Spectrometry', 'Nanotechnology'],
+    visibility: visibility2
+  }
   let(:visibility1) { "authenticated" }
   let(:visibility2) { "restricted" }
   let(:batch) { [work1.id, work2.id] }
@@ -67,6 +91,7 @@ RSpec.describe BatchEditForm do
       expect(form.model.language).to match_array ["en"]
       expect(form.model.identifier).to match_array ["id1", "id2"]
       expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
+      expect(form.model.project).to match_array ["Chemical History of Electronics", "Mass Spectrometry", "Nanotechnology"]
     end
 
     describe "when works have different visibilities" do

--- a/spec/forms/batch_upload_form_spec.rb
+++ b/spec/forms/batch_upload_form_spec.rb
@@ -15,7 +15,7 @@ describe BatchUploadForm do
   describe "form terms" do
     it "exclude defaults" do
       # title and resource type go on the upload form
-      expect(form.primary_terms.count).to eq 24
+      expect(form.primary_terms.count).to eq 25
       expect(form.primary_terms).not_to include :keyword
     end
     it "requires 2 fields" do

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -10,7 +10,7 @@ describe CurationConcerns::GenericWorkForm do
 
   describe "form terms" do
     it "exclude defaults" do
-      expect(form.primary_terms.count).to eq 26
+      expect(form.primary_terms.count).to eq 27
       expect(form.primary_terms).not_to include :keyword
     end
     it "requires 2 fields" do

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -17,7 +17,5 @@ describe CurationConcerns::GenericWorkForm do
       expect(form.required_fields.count).to eq 2
     end
   end
-
   it_behaves_like "work_form_behavior"
-
 end

--- a/spec/indexers/chf/generic_work_indexer_spec.rb
+++ b/spec/indexers/chf/generic_work_indexer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe CHF::GenericWorkIndexer do
       w.editor = ["the editor"]
       w.attributed_to = ["presumptive author"]
       w.engraver = ["engraving professional"]
+      w.project = ['Mass Spectrometry', 'Nanotechnology']
       w.save
     end
   end
@@ -52,6 +53,10 @@ RSpec.describe CHF::GenericWorkIndexer do
     expect(solr_document[mapper.solr_name('maker_facet', :facetable)]).to include 'publishing house'
     expect(solr_document[mapper.solr_name('maker_facet', :facetable)]).to include 'presumptive author'
     expect(solr_document[mapper.solr_name('maker_facet', :facetable)].size).to eq 5
+  end
+
+  it 'indexes the project' do
+    expect(solr_document['project_tesim']).to match_array ["Mass Spectrometry", "Nanotechnology"]
   end
 
   describe "with a real file child" do

--- a/spec/views/curation_concerns/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_metadata.html.erb_spec.rb
@@ -49,6 +49,7 @@ describe 'curation_concerns/base/_form_metadata.html.erb', type: :view do
       expect(names).to include "generic_work[place_of_manufacture][]"
       expect(names).to include "generic_work[place_of_publication][]"
       expect(names).to include "generic_work[place_of_creation][]"
+
     end
 
     it "renders a nested attribute field" do
@@ -64,6 +65,10 @@ describe 'curation_concerns/base/_form_metadata.html.erb', type: :view do
 
     it "renders exhibition as a select" do
       expect(page).to have_selector "select[id='generic_work_exhibition']"
+    end
+    it "renders project as a select" do
+      expect(page).to have_content('Science and Disability')
+      expect(page).to have_selector "select[id='generic_work_project']"
     end
   end
 end


### PR DESCRIPTION
A "Project" metadata field for GenericWorks. Fixes #1240.
Includes tests, including for the export.

Note: I discovered we didn't have tests for the exporters, so this PR includes a minimum of exporter test functionality-- just enough to be able to assert that the new field is in fact included in the export.

I'll flesh it out soon in another PR.