### PR TITLE
Display adjustments to provenance/provenance notes

### DIFF
--- a/app/assets/stylesheets/local/work-show.scss
+++ b/app/assets/stylesheets/local/work-show.scss
@@ -26,6 +26,9 @@
     margin-right: auto;
   }
 
+  #collapseProvenanceNotes {
+    margin-top: 1em;
+  }
 
   @media (min-width: $screen-sm-min) {
     padding: 0 15px;

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -123,10 +123,10 @@
             <td>
               <%=format_description(provenance_summary) %>
               <% unless provenance_notes.nil? %>
-                <a data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
-                  Notes...
-                </a><br/>
-                <div class="collapse" id="collapseExample">
+                <a data-toggle="collapse" href="#collapseProvenanceNotes"
+                  role="button" aria-expanded="false"
+                  aria-controls="collapseProvenanceNotes">Show notes</a>
+                <div class="collapse" id="collapseProvenanceNotes">
                   <%= format_description(provenance_notes) %>
                 </div>
               <% end %>


### PR DESCRIPTION
Several small changes to the feature in progress:

 - Added horizontal space under the show notes field
- Renamed the show notes link to read "Show notes" instead of Notes...
- Changed the html #id of the provenance notes div