### PR TITLE
Add provenance to the new work feature test.

### DIFF
--- a/spec/features/new_work_feature_spec.rb
+++ b/spec/features/new_work_feature_spec.rb
@@ -74,12 +74,15 @@ RSpec.feature "Work form", js: true do
       find_by_id("#{gwia}_2_text")    .set(inscription_text_2)
     end
 
-    find_by_id("generic_work_provenance").set ("""<a href=\"https://www.nytimes.com\" target=\"_blank\">The New York Times.</a>
+    find_by_id("generic_work_description").set ("""<a href=\"https://www.nytimes.com\" target=\"_blank\">The New York Times.</a>
           <i>italics</i>
           <b>bold</b>
           <cite>citation</cite>
           <goat>this tag should not make it, except for its contents</goat>
           <i>and this tag should get closed.""")
+
+    # provenance_string is a method defined at the bottom of this file.
+    find_by_id('generic_work_provenance').set(provenance_string)
 
     select "Image", from: "generic_work[resource_type][]"
 
@@ -91,6 +94,7 @@ RSpec.feature "Work form", js: true do
       newly_added_work = GenericWork.last
       expect(page).to have_current_path(curation_concerns_generic_work_path(newly_added_work.id), only_path: true)
     }.to change(GenericWork, :count).by(1)
+
     expect(page).to have_css("h1", text: title)
     expect(page).to have_css(".attribute.resource_type", text: "Image")
     expect(page).to have_text("Sierra Bib. No.: #{bib_num}")
@@ -106,6 +110,17 @@ RSpec.feature "Work form", js: true do
     expect(page.source).to include("<cite>citation</cite>")
     expect(page.source).to include("<i>and this tag should get closed.</i>")
 
+    # Provenance notes:
+    notes = page.find("#collapseProvenanceNotes", :visible => :all)
+    expect(notes.visible?).to be false
+    click_link 'Show notes'
+    expect(notes.visible?).to be true
+
+    #The code should correctly replace carriage returns with <p> tags:
+    note_arr = notes['innerHTML'].scan(/<p>.*<\/p>/)
+    expect(note_arr.length).to eq 2
+    expect(note_arr.first).to  start_with("<p>[1]")
+    expect(note_arr.second).to start_with("<p>[2]")
 
     # Regression test for bug
     # https://github.com/sciencehistory/chf-sufia/issues/1049
@@ -144,4 +159,9 @@ RSpec.feature "Work form", js: true do
       end
     end
   end
+end
+
+
+def provenance_string
+  "[possibly Willem Gruyter, Amsterdam (sale, Philippus Schley, Amsterdam, 8 August 1804, lot 82; sale, Philippus Schley, Amsterdam, 23 August 1808, lot 76)]. [1]\n\nPrivate Collection, Vermont, before 1967 and probably prior to 20th cent. (to Koetser). [2]\n\n[David M. Koetser Galleries, New York, after 1923 and prior to 1965 (to Fisher)].\n\nFisher Scientific, Pittsburgh, PA; Fisher Scientific International Inc., Hampton, NH, acquired by Chester Fisher, prior to 1967 until 2000.\n\nThe Chemical Heritage Foundation, 2000 (from Scientific International Inc.).\n\nNotes:\n[1] This auction lists lot 82 as a painting by Juncker with a very similar description to the present painting.\n\n[2] An internal note from Chester Fisher described the painting as having been \"located by Koetser Galleries in the Vermont home of a U.S.A. Naval Commander, in whose family it had been for several generations.\" David M. Koetser opened Koetser Galleries in New York shortly after 1923. The New York gallery in closed in 1967, when David M. Koetser moved to Zurich. The painting must have been sold to Chester Fisher before his death in 1965.)\n"
 end


### PR DESCRIPTION
Using actual data from a museum provenance record.