### PR TITLE
attempt to track 'Back to search reuslts' clicks

### DIFF
--- a/app/assets/javascripts/chf_ga_events.js
+++ b/app/assets/javascripts/chf_ga_events.js
@@ -13,3 +13,14 @@ $(document).on('click', '*[data-analytics-category]', function(e) {
              e.target.getAttribute("data-analytics-value")
             ]);
 });
+
+
+// Track the "Back to search results" link specially, because we don't
+// control it's data attributes from sufia
+$(document).on("click", "ul.breadcrumb li a", function(e) {
+  if (e.target && e.target.text == "Back to search results") {
+    _gaq.push(['_trackEvent',
+               "interesting_clicks",
+               "back_to_search_results"]);
+  }
+});


### PR DESCRIPTION
Without customizing sufia, so it doesn't make it very easy to hook into to issue a google event, so we hackily watch for clicks and look at actual text of link