### PR TITLE
Tell travis to update rubygems before running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 script: bundle exec rake dev:spec_with_app_load
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ addons:
     - ffmpeg
 # END NOTE
 
-
+before_install:
+  # Try to get around bug that's weirdly suddenly started affecting us.
+  # https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html
+  - gem update --system
 before_script:
   - jdk_switcher use oraclejdk8
   - psql -c 'create database scihist_sufia_test;' -U postgres


### PR DESCRIPTION
Try get around weird rubygems bug that's suddenly started affecting us:
https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html

Looks like this in travis log with test failure:

```
/home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```

Not sure why it doesn't reproduce locally, just on travis.